### PR TITLE
Add AWS alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfplan
+crash.log
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Personal/sensitive variables (keep terraform.tfvars if it contains sensitive data)
+terraform.tfvars

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/alert.tf
+++ b/alert.tf
@@ -1,0 +1,31 @@
+variable "notification_email" {
+  description = "Budget alerts will be sent to this email address."
+  type        = string
+}
+
+resource "aws_budgets_budget" "monthly_budget" {
+  name         = "monthly-budget"
+  budget_type  = "COST"
+  limit_amount = "5"
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 5
+    threshold_type             = "ABSOLUTE_VALUE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.notification_email]
+    subscriber_sns_topic_arns  = [aws_sns_topic.budget_alerts.arn]
+  }
+}
+
+resource "aws_sns_topic" "budget_alerts" {
+  name = "budget-alerts"
+}
+
+resource "aws_sns_topic_subscription" "email_subscription" {
+  topic_arn = aws_sns_topic.budget_alerts.arn
+  protocol  = "email"
+  endpoint  = var.notification_email
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"  # Tokyo region
+} 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,1 @@
+notification_email = "your-email@example.com" 


### PR DESCRIPTION
## なぜやるか

- AWS利用料金の予期しない高額請求を防ぐため
- 月額5ドルの予算上限を設定し、コスト管理を自動化するため

## なにをやったのか

- AWS Budgets設定をTerraformで追加（月額5ドル上限）
- 予算超過時のメール通知機能を実装
- SNSを使った通知システムを構築

## 動作確認の手順
1. 通知メールアドレスを設定
`export TF_VAR_notification_email="your-email@example.com"`

2. Terraformの初期化
`terraform init`
3. 実行計画の確認
`terraform plan `
4. インフラの作成
`terraform apply`
("yes"を入力して実行)

aws_budgets_budget
<img width="1235" height="280" alt="スクリーンショット 2025-07-12 12 09 33" src="https://github.com/user-attachments/assets/2308e1da-3365-4497-b31c-8c63ba624ef3" />
aws_sns_topic
<img width="1217" height="387" alt="スクリーンショット 2025-07-12 12 09 48" src="https://github.com/user-attachments/assets/2cf44c1f-9cd4-4340-9f5f-6cd5fa578bf2" />
aws_sns_topic_subscription
<img width="1194" height="387" alt="スクリーンショット 2025-07-12 12 09 57" src="https://github.com/user-attachments/assets/8be817a1-1e6f-48db-a1cf-6732e11701a5" />