### PR TITLE
Add EC2

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -1,0 +1,34 @@
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_key_pair" "honahuku_thinkpad_20250621" {
+  key_name   = "honahuku_thinkpad_20250621"
+  public_key = file("~/.ssh/id_rsa.pub")
+}
+
+resource "aws_instance" "kdg-aws-20250621" {
+  ami = data.aws_ami.ubuntu.id
+  # AWS の無力枠を使いたいため t3.micro を使う
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "kdg-aws-20250621",
+  }
+  vpc_security_group_ids = [aws_security_group.ssh_enable.id]
+  key_name = aws_key_pair.honahuku_thinkpad_20250621.key_name
+}
+

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,0 +1,42 @@
+variable "vpc_id" {
+  description = "vpc-0adabba7c83abd69a"
+  type        = string
+}
+
+data "aws_vpc" "main" {
+  default = true
+}
+
+resource "aws_security_group" "ssh_enable" {
+  vpc_id = data.aws_vpc.main.id
+  name   = "ssh-enable"
+  tags = {
+    Name = "ssh-enable",
+  }
+}
+
+resource "aws_vpc_security_group_egress_rule" "any" {
+  security_group_id = aws_security_group.ssh_enable.id
+
+  cidr_ipv4 = "0.0.0.0/0"
+  # any
+  ip_protocol = "-1"
+
+  tags = {
+    Name = "any",
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ssh_enable" {
+
+  security_group_id = aws_security_group.ssh_enable.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 22
+  ip_protocol = "tcp"
+  to_port     = 22
+
+  tags = {
+    Name = "ssh-enable",
+  }
+}


### PR DESCRIPTION
## なぜやるか

- EC2インスタンスをTerraformで管理し、インフラをコード化するため
- SSH接続でサーバー操作できる環境を構築するため

## なにをやったのか

- TerraformでAWS EC2インスタンスの作成設定を追加
- SSH接続用のキーペア管理をTerraformで自動化
- セキュリティグループでSSHのアクセス許可設定を追加
- 既存のデフォルトVPCを利用したネットワーク設定
- .gitignoreにTerraform状態ファイルとSSH秘密鍵の除外設定を追加

## 動作確認の手順
1. Terraformの初期化
`terraform init`

2. 実行計画の確認
`terraform plan
`
3. インフラの作成
`terraform apply`
("yes"を入力して実行)

4. SSH接続の確認
AWSコンソールでパブリックIPを確認後、以下を実行
`ssh -i ~/.ssh/id_rsa ubuntu@<パブリックIP>`

5. リソースの削除
`terraform destroy`
( "yes"を入力して実行)

<img width="1242" height="263" alt="スクリーンショット 2025-07-18 13 42 53" src="https://github.com/user-attachments/assets/e742e580-659e-4a79-9dc2-246038d1def2" />

<img width="1211" height="757" alt="スクリーンショット 2025-07-18 13 43 28" src="https://github.com/user-attachments/assets/f96a9472-2dde-4d83-87ec-6553fe793b63" />
<img width="782" height="600" alt="スクリーンショット 2025-07-18 13 42 46" src="https://github.com/user-attachments/assets/4652082c-4f62-42be-a9a1-32d903d6e80d" />
<img width="1220" height="241" alt="スクリーンショット 2025-07-18 13 47 21" src="https://github.com/user-attachments/assets/5abbba13-71a6-48f6-a89d-5acb1924fd7a" />