### PR TITLE
Add AWS Lambda

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -1,0 +1,117 @@
+# CI/CD側でlambdaのソースコードを格納するための箱
+# resource "aws_s3_bucket" "lambda_artifacts" {
+#   # AWS S3 で一意である(重複がない)必要がある
+#   # 例) kdg-aws-2025-ここに自分のgithubのユーザー名-lambda-artifacts
+#   bucket = "aws-2025-hiramoto-lambda-artifacts"
+#   tags = {
+#     # bucket に指定した内容と同じものを書く
+#     Name = "aws-2025-hiramoto-lambda-artifacts"
+#   }
+# }
+
+# lambda 実行時に必要な権限をまとめる role を定義する
+resource "aws_iam_role" "lambda" {
+  name = "iam_for_lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        },
+        Effect = "Allow",
+        Sid    = ""
+      }
+    ]
+  })
+}
+
+# CloudWatch Logs への書き込み権限を 定義した role に対して付与する
+resource "aws_iam_role_policy_attachment" "lambda_logs" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# GetAccountSettings も実行時に必要な権限なので付与する
+resource "aws_iam_role_policy" "get_account_settings" {
+  name = "GetAccountSettingsPermission"
+  role = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = "lambda:GetAccountSettings"
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+# 初回のみ利用する Lambda のファイルを生成
+# data "archive_file" "initial_lambda_package" {
+#   type        = "zip"
+#   output_path = "${path.module}/.temp_files/lambda.zip"
+#   source {
+#     # 実際に動作するPythonコードに修正
+#     content = <<EOF
+# import json
+
+# def lambda_handler(event, context):
+#     return {
+#         'statusCode': 200,
+#         'headers': {
+#             'Content-Type': 'application/json'
+#         },
+#         'body': json.dumps({
+#             'message': 'Hello from Lambda!',
+#             'function_name': context.function_name,
+#             'request_id': context.aws_request_id,
+#             'event': event
+#         })
+#     }
+# EOF
+#     filename = "lambda_function.py"
+#   }
+# }
+
+# (初回のみ)LambdaのファイルをS3にアップロード
+# resource "aws_s3_object" "lambda_file" {
+#   bucket = aws_s3_bucket.lambda_artifacts.id
+#   key    = "initial.zip"
+#   source = data.archive_file.initial_lambda_package.output_path
+# }
+
+# Lambda関数を生成
+# resource "aws_lambda_function" "first_function" {
+#   function_name = "first-function"
+#   role          = aws_iam_role.lambda.arn
+#   handler       = "lambda_function.lambda_handler"
+#   runtime       = "python3.12"
+#   timeout       = 120
+#   publish       = true
+#   s3_bucket     = aws_s3_bucket.lambda_artifacts.id
+#   s3_key        = aws_s3_object.lambda_file.key
+#   depends_on = [aws_s3_object.lambda_file]
+# }
+
+# 外部からリクエストを飛ばすためのエンドポイント
+# resource "aws_lambda_function_url" "first_function" {
+#   function_name      = aws_lambda_function.first_function.function_name
+#   authorization_type = "NONE"
+# }
+
+# 出力値を追加
+# output "lambda_function_url" {
+#   value = aws_lambda_function_url.first_function.function_url
+# }
+
+# output "lambda_function_name" {
+#   value = aws_lambda_function.first_function.function_name
+# }
+
+# output "s3_bucket_name" {
+#   value = aws_s3_bucket.lambda_artifacts.id
+# }


### PR DESCRIPTION
## なぜやるか

- Lambdaの実行環境をTerraformで管理するため

## なにをやったのか

- main.tfにTerraformとAWSプロバイダーの設定を追加（東京リージョン使用）
- Lambda実行用のIAMロール作成設定を追加
- CloudWatch Logsへの書き込み権限をIAMロールに付与
- Lambda関数のGetAccountSettings権限を設定

## 動作確認の手順
 1. Terraformの初期化
`terraform init`

2. 設定の確認
`terraform plan`

3. IAMロールの作成
`terraform apply`(yesを入力)

4. リソースの削除
`terraform destroy `

作成したlambda
<img width="1470" alt="スクリーンショット 2025-07-05 15 00 38" src="https://github.com/user-attachments/assets/0714009a-fce4-4167-a054-2bece542a284" />

返ってきたjson
url：https://in7exvelvvy7byy5tweuefnbnm0rfafw.lambda-url.ap-northeast-1.on.aws/
<img width="742" alt="スクリーンショット 2025-07-05 13 55 33" src="https://github.com/user-attachments/assets/84a7b4f3-fa36-485d-a9bd-70cd147942ff" />

作成した lamda と s3 バケットをコメントアウトして apply し lamda と s3 が削除されていることを確認
<img width="1470" alt="スクリーンショット 2025-07-05 15 00 58" src="https://github.com/user-attachments/assets/879f1294-8c48-4200-9281-5435341545e4" />
<img width="1470" alt="スクリーンショット 2025-07-05 15 00 11" src="https://github.com/user-attachments/assets/a5e20295-7372-4f6b-b267-ea11af699c7d" />
